### PR TITLE
BUGFIX: Fix some styling issues on demo form

### DIFF
--- a/DistributionPackages/Neos.Demo.UserRegistration/Resources/Private/Fusion/Override/Form/Registration.fusion
+++ b/DistributionPackages/Neos.Demo.UserRegistration/Resources/Private/Fusion/Override/Form/Registration.fusion
@@ -2,24 +2,24 @@ prototype(Neos.Demo:Content.Registration) {
   process {
     content >
     content = afx`
-      <div class="form-group">
-        <Neos.Fusion.Form:FieldContainer field.name="firstName" label="First Name" attributes.style="display:flex;flex-direction:column;justify-content:space-between;">
-          <Neos.Fusion.Form:Input attributes.style="width:300px;margin-bottom:15px;" />
+      <fieldset class="space-y-6 mb-8 max-w-[300px]">
+        <Neos.Fusion.Form:FieldContainer field.name="firstName" label="First Name" attributes.class="flex flex-col">
+          <Neos.Fusion.Form:Input attributes.class="form-input" />
         </Neos.Fusion.Form:FieldContainer>
-        <Neos.Fusion.Form:FieldContainer field.name="lastName" label="Last Name" attributes.style="display:flex;flex-direction:column;justify-content:space-between;">
-          <Neos.Fusion.Form:Input attributes.style="width:300px;margin-bottom:15px;" />
+        <Neos.Fusion.Form:FieldContainer field.name="lastName" label="Last Name" attributes.class="flex flex-col">
+          <Neos.Fusion.Form:Input attributes.class="form-input" />
         </Neos.Fusion.Form:FieldContainer>
-        <Neos.Fusion.Form:FieldContainer field.name="username" label="Username" attributes.style="display:flex;flex-direction:column;justify-content:space-between;">
-          <small>(lowercase letters and numbers only)</small>
-          <Neos.Fusion.Form:Input attributes.style="width:300px;margin-bottom:15px;" />
+        <Neos.Fusion.Form:FieldContainer field.name="username" label="Username" attributes.class="flex flex-col">
+            <Neos.Fusion.Form:Input attributes.class="form-input" />
+            <small>(lowercase letters and numbers only)</small>
         </Neos.Fusion.Form:FieldContainer>
-        <Neos.Fusion.Form:FieldContainer field.name="password" label="Password" attributes.style="display:flex;flex-direction:column;justify-content:space-between;">
-          <Neos.Fusion.Form:Password attributes.style="width:300px" />
+        <Neos.Fusion.Form:FieldContainer field.name="password" label="Password" attributes.class="flex flex-col">
+          <Neos.Fusion.Form:Password attributes.class="form-input" />
         </Neos.Fusion.Form:FieldContainer>
-        <Neos.Fusion.Form:FieldContainer field.name="company" label="" attributes.style="visibility:hidden;">
+        <Neos.Fusion.Form:FieldContainer field.name="company" label="" attributes.class="hidden">
           <Neos.Fusion.Form:Input />
         </Neos.Fusion.Form:FieldContainer>
-      </div>
+      </fieldset>
     `
 
     schema {

--- a/DistributionPackages/Neos.Demo.UserRegistration/Resources/Private/Fusion/Override/Form/Registration.fusion
+++ b/DistributionPackages/Neos.Demo.UserRegistration/Resources/Private/Fusion/Override/Form/Registration.fusion
@@ -3,20 +3,20 @@ prototype(Neos.Demo:Content.Registration) {
     content >
     content = afx`
       <fieldset class="space-y-6 mb-8 max-w-[300px]">
-        <Neos.Fusion.Form:FieldContainer field.name="firstName" label="First Name" attributes.class="flex flex-col">
-          <Neos.Fusion.Form:Input attributes.class="form-input" />
+        <Neos.Fusion.Form:FieldContainer field.name="firstName" label="First Name">
+          <Neos.Fusion.Form:Input />
         </Neos.Fusion.Form:FieldContainer>
-        <Neos.Fusion.Form:FieldContainer field.name="lastName" label="Last Name" attributes.class="flex flex-col">
-          <Neos.Fusion.Form:Input attributes.class="form-input" />
+        <Neos.Fusion.Form:FieldContainer field.name="lastName" label="Last Name">
+          <Neos.Fusion.Form:Input />
         </Neos.Fusion.Form:FieldContainer>
-        <Neos.Fusion.Form:FieldContainer field.name="username" label="Username" attributes.class="flex flex-col">
-            <Neos.Fusion.Form:Input attributes.class="form-input" />
+        <Neos.Fusion.Form:FieldContainer field.name="username" label="Username">
+            <Neos.Fusion.Form:Input />
             <small>(lowercase letters and numbers only)</small>
         </Neos.Fusion.Form:FieldContainer>
-        <Neos.Fusion.Form:FieldContainer field.name="password" label="Password" attributes.class="flex flex-col">
-          <Neos.Fusion.Form:Password attributes.class="form-input" />
+        <Neos.Fusion.Form:FieldContainer field.name="password" label="Password">
+          <Neos.Fusion.Form:Password />
         </Neos.Fusion.Form:FieldContainer>
-        <Neos.Fusion.Form:FieldContainer field.name="company" label="" attributes.class="hidden">
+        <Neos.Fusion.Form:FieldContainer field.name="company" label="" class="hidden">
           <Neos.Fusion.Form:Input />
         </Neos.Fusion.Form:FieldContainer>
       </fieldset>

--- a/DistributionPackages/Neos.Demo.UserRegistration/Resources/Private/Fusion/Override/Form/Registration.fusion
+++ b/DistributionPackages/Neos.Demo.UserRegistration/Resources/Private/Fusion/Override/Form/Registration.fusion
@@ -3,18 +3,18 @@ prototype(Neos.Demo:Content.Registration) {
     content >
     content = afx`
       <fieldset class="space-y-6 mb-8 max-w-[300px]">
-        <Neos.Fusion.Form:FieldContainer field.name="firstName" label="First Name">
-          <Neos.Fusion.Form:Input />
+        <Neos.Fusion.Form:FieldContainer field.name="firstName" label="First Name" >
+          <Neos.Fusion.Form:Input attributes.required={true} />
         </Neos.Fusion.Form:FieldContainer>
         <Neos.Fusion.Form:FieldContainer field.name="lastName" label="Last Name">
-          <Neos.Fusion.Form:Input />
+          <Neos.Fusion.Form:Input attributes.required={true} />
         </Neos.Fusion.Form:FieldContainer>
         <Neos.Fusion.Form:FieldContainer field.name="username" label="Username">
-            <Neos.Fusion.Form:Input />
+            <Neos.Fusion.Form:Input attributes.required={true} />
             <small>(lowercase letters and numbers only)</small>
         </Neos.Fusion.Form:FieldContainer>
         <Neos.Fusion.Form:FieldContainer field.name="password" label="Password">
-          <Neos.Fusion.Form:Password />
+          <Neos.Fusion.Form:Password attributes.required={true} />
         </Neos.Fusion.Form:FieldContainer>
         <Neos.Fusion.Form:FieldContainer field.name="company" label="" class="hidden">
           <Neos.Fusion.Form:Input />

--- a/DistributionPackages/Neos.Demo.UserRegistration/Resources/Private/Fusion/Override/Form/Registration.fusion
+++ b/DistributionPackages/Neos.Demo.UserRegistration/Resources/Private/Fusion/Override/Form/Registration.fusion
@@ -16,8 +16,8 @@ prototype(Neos.Demo:Content.Registration) {
         <Neos.Fusion.Form:FieldContainer field.name="password" label="Password">
           <Neos.Fusion.Form:Password attributes.required={true} />
         </Neos.Fusion.Form:FieldContainer>
-        <Neos.Fusion.Form:FieldContainer field.name="company" label="" class="hidden">
-          <Neos.Fusion.Form:Input />
+        <Neos.Fusion.Form:FieldContainer field.name="company" label="" attributes.style="visibility:hidden;height:0;margin:0">
+          <Neos.Fusion.Form:Input attributes.class="p-0 text-sm" />
         </Neos.Fusion.Form:FieldContainer>
       </fieldset>
     `

--- a/DistributionPackages/Neos.Demo.UserRegistration/Resources/Private/Fusion/Override/Form/Registration.fusion
+++ b/DistributionPackages/Neos.Demo.UserRegistration/Resources/Private/Fusion/Override/Form/Registration.fusion
@@ -10,7 +10,7 @@ prototype(Neos.Demo:Content.Registration) {
           <Neos.Fusion.Form:Input attributes.required={true} />
         </Neos.Fusion.Form:FieldContainer>
         <Neos.Fusion.Form:FieldContainer field.name="username" label="Username">
-            <Neos.Fusion.Form:Input attributes.required={true} />
+            <Neos.Fusion.Form:Input attributes.required={true} attributes.pattern="[a-z0-9]+" />
             <small>(lowercase letters and numbers only)</small>
         </Neos.Fusion.Form:FieldContainer>
         <Neos.Fusion.Form:FieldContainer field.name="password" label="Password">


### PR DESCRIPTION
Related to #7 

This is based on this commit (and some following): https://github.com/neos/Neos.Demo/pull/142/commits/1eb098d3333ef48e440863bbe8389ed7255b430b

* Use tailwind classes
* Fix margin between last input field and submit button
* Add styling for errors
* Add `required` attributes
* Add `pattern` attribute to the username field
* Add id and action to form elements to jump back to form after submit

### Before
<img width="346" alt="CleanShot 2022-07-27 at 20 15 04@2x" src="https://user-images.githubusercontent.com/4510166/181343430-3b1b494b-4898-408b-a9b2-b7331d87d1ab.png">

### After
<img width="510" alt="CleanShot 2022-07-27 at 20 09 43@2x" src="https://user-images.githubusercontent.com/4510166/181342519-6ed17915-2e7d-4c99-90c6-037e1f0962c5.png">
